### PR TITLE
Fix epsilon bug

### DIFF
--- a/torchinterp1d/interp1d.py
+++ b/torchinterp1d/interp1d.py
@@ -142,7 +142,7 @@ class Interp1d(torch.autograd.Function):
             v['slopes'] = (
                     (v['y'][:, 1:]-v['y'][:, :-1])
                     /
-                    (eps + v['x'][:, 1:]-v['x'][:, :-1])
+                    (eps + (v['x'][:, 1:]-v['x'][:, :-1]))
                 )
 
             # now build the linear interpolation


### PR DESCRIPTION
Should fix #5.

The problem is that `eps + x == x` if `x` is large enough, so `eps + x - x == 0.`, and the slope will be infinite. So we first need to subtract and then add `eps`.