### PR TITLE
Use torch.searchsorted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # torchinterp1d
 ## CUDA 1-D interpolation for Pytorch
 
+Requires PyTorch >= 1.6 (due to [torch.searchsorted](https://pytorch.org/docs/master/generated/torch.searchsorted.html)).
+
 ## Presentation
 
 This repository implements an `Interp1d` class that overrides torch.autograd.Function, enabling

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     packages=['torchinterp1d'],
     keywords='interp1d torch',
     install_requires=[
-        'torchsearchsorted @ git+https://github.com/aliutkus/torchsearchsorted',
+        'torch==1.6',
     ],
     )

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,6 @@ setup(
     packages=['torchinterp1d'],
     keywords='interp1d torch',
     install_requires=[
-        'torch==1.6',
+        'torch>=1.6',
     ],
     )

--- a/torchinterp1d/interp1d.py
+++ b/torchinterp1d/interp1d.py
@@ -1,11 +1,5 @@
 import torch
 import contextlib
-SEARCHSORTED_AVAILABLE = True
-try:
-    from torchsearchsorted import searchsorted
-except ImportError:
-    SEARCHSORTED_AVAILABLE = False
-
 
 class Interp1d(torch.autograd.Function):
     def __call__(self, x, y, xnew, out=None):
@@ -37,14 +31,6 @@ class Interp1d(torch.autograd.Function):
             Tensor for the output. If None: allocated automatically.
 
         """
-        # checking availability of the searchsorted pytorch module
-        if not SEARCHSORTED_AVAILABLE:
-            raise Exception(
-                'The interp1d function depends on the '
-                'torchsearchsorted module, which is not available.\n'
-                'You must get it at ',
-                'https://github.com/aliutkus/torchsearchsorted\n')
-
         # making the vectors at least 2D
         is_flat = {}
         require_grad = {}
@@ -107,7 +93,7 @@ class Interp1d(torch.autograd.Function):
 
         # calling searchsorted on the x values.
         ind = ynew.long()
-        searchsorted(v['x'].contiguous(), v['xnew'].contiguous(), ind)
+        torch.searchsorted(v['x'].contiguous(), v['xnew'].contiguous(), out=ind)
 
         # the `-1` is because searchsorted looks for the index where the values
         # must be inserted to preserve order. And we want the index of the


### PR DESCRIPTION
Since [torch.searchsorted](https://pytorch.org/docs/stable/generated/torch.searchsorted.html#torch-searchsorted) is now in the stable 1.6 release, here is a PR changing the implementation to the official one.
Furthermore I added the dependency on PyTorch 1.6 and added a line in the README.

I was wondering if keeping the old solution, using @aliutkus torchsearchsorted, might be a good idea for people that can't upgrade to PyTorch 1.6 yet. Since there's no PyPi release anyways, I would suggest tagging both the last release and this one and maybe provide `pip install` commands for both in the README? Let me know if you think this is sensible, I can gladly add this.