### PR TITLE
removed torch import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,6 @@ from setuptools import setup
 from codecs import open
 from os import path
 
-# trying to import the required torch package
-try:
-    import torch
-except ImportError:
-    raise Exception('qsketch requires PyTorch to be installed. aborting')
-
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file


### PR DESCRIPTION
As suggested by @jwodder in [this thread](https://discuss.python.org/t/optional-dependencies-ordering/52108/2), the `torch` import in the `setup.py` file is not necessary because normal package installation will already ensure that `torch` is installed. Keeping the import is problematic for further packaging (as described [here](https://discuss.python.org/t/optional-dependencies-ordering/52108)).