### PR TITLE
Fix Backward loop issue on pytorch 2.5

### DIFF
--- a/torchinterp1d/interp1d.py
+++ b/torchinterp1d/interp1d.py
@@ -147,7 +147,7 @@ class Interp1d(torch.autograd.Function):
                 ynew = ynew.view(original_xnew_shape)
 
         ctx.save_for_backward(ynew, *saved_inputs)
-        return ynew
+        return ynew.detach()
 
     @staticmethod
     def backward(ctx, grad_out):


### PR DESCRIPTION
When I tried to back propagate on PyTorch 2.5.1, the program stuck at `loss.backward()`. After some investigation, I found the following issue:

When I add a breakpoint at https://github.com/aliutkus/torchinterp1d/blob/4e7533dce96edf4aa4549bc75cf532d9e782befb/torchinterp1d/interp1d.py#L155

The `grad_fn` of `ctx.saved_tensors[0]` is `<Interp1dBackward>`, causing a loop backward call.

When I add a breakpoint at https://github.com/aliutkus/torchinterp1d/blob/4e7533dce96edf4aa4549bc75cf532d9e782befb/torchinterp1d/interp1d.py#L149

The `grad_fn` of `ynew` is  `<AddBackward0>`, which means the grad_fn of `ctx.saved_tensors[0]` is touched between forward and backward. I tried to add `.detach()` after calling `interp1d`, but the results were the same.

I suspect that the PyTorch auto_grad engine modifies the `grad_fn` of `ynew` in-place after some version. Adding a `detach()` in the forward function resolves this problem.
